### PR TITLE
Update move tab shortcuts

### DIFF
--- a/src/GToolkit-World/GtHome.class.st
+++ b/src/GToolkit-World/GtHome.class.st
@@ -23,6 +23,13 @@ GtHome >> collectHomeSectionStencils [
 ]
 
 { #category : #building }
+GtHome >> createSectionsHolder [
+	^ BrVerticalPane new
+		hMatchParent;
+		vFitContent
+]
+
+{ #category : #building }
 GtHome >> createSectionWrapperFor: aSectionStencil [
 	^ BrAsyncWidget new
 			margin: (BlInsets all: self spaceGap);
@@ -33,13 +40,6 @@ GtHome >> createSectionWrapperFor: aSectionStencil [
 			postAction: [ :theLazyElement | theLazyElement constraintsDo: [ :c | 
 				c vertical fitContent ] ];
 			stencil: aSectionStencil
-]
-
-{ #category : #building }
-GtHome >> createSectionsHolder [
-	^ BrVerticalPane new
-		hMatchParent;
-		vFitContent
 ]
 
 { #category : #building }

--- a/src/GToolkit-World/GtHomeSection.class.st
+++ b/src/GToolkit-World/GtHomeSection.class.st
@@ -61,6 +61,30 @@ GtHomeSection >> newCard [
 ]
 
 { #category : #'instance creation' }
+GtHomeSection >> newCardsContainer [
+	^ BlElement new
+		layout: BlFlowLayout new;
+		constraintsDo: [ :c |
+			c horizontal matchParent.
+			c vertical fitContent ];
+		padding: (BlInsets all: 0)
+]
+
+{ #category : #'instance creation' }
+GtHomeSection >> newCardWithoutIcon [
+	^ BrCard new
+		aptitude: (BrShadowAptitude new beLarge)+
+			(BrDescriptionAptitude new readonly glamorousRegularFont descriptionDo: [:e | e padding: (BlInsets all: 10)]) +
+			(BrGlamorousButtonExteriorAptitude new backgroundPaint: BrGlamorousColors secondaryHeaderBackgroundColor);
+		layout: (BlLinearLayout horizontal alignCenter cellSpacing: 0);
+		geometry: (BlRoundedRectangleGeometry cornerRadius: 2);
+		constraintsDo: [ :c |
+			c horizontal exact: 250.
+			c vertical exact: 100 ];
+		margin: (BlInsets top: self spaceGap left: self spaceGap * 2 bottom: self spaceGap right: self spaceGap * 2)
+]
+
+{ #category : #'instance creation' }
 GtHomeSection >> newCardWithTitle: aTitle description: aDescription action: aBlock [ 
 	| cardElement |	
 	self deprecated: 'not used'.
@@ -95,30 +119,6 @@ GtHomeSection >> newCardWithTitle: aTitle description: aDescription picture: anE
 "			border: (BlBorder paint: BrGlamorousColors defaultButtonBorderColor); "
 			preventMeAndChildrenMouseEvents);
 		action: aBlock
-]
-
-{ #category : #'instance creation' }
-GtHomeSection >> newCardWithoutIcon [
-	^ BrCard new
-		aptitude: (BrShadowAptitude new beLarge)+
-			(BrDescriptionAptitude new readonly glamorousRegularFont descriptionDo: [:e | e padding: (BlInsets all: 10)]) +
-			(BrGlamorousButtonExteriorAptitude new backgroundPaint: BrGlamorousColors secondaryHeaderBackgroundColor);
-		layout: (BlLinearLayout horizontal alignCenter cellSpacing: 0);
-		geometry: (BlRoundedRectangleGeometry cornerRadius: 2);
-		constraintsDo: [ :c |
-			c horizontal exact: 250.
-			c vertical exact: 100 ];
-		margin: (BlInsets top: self spaceGap left: self spaceGap * 2 bottom: self spaceGap right: self spaceGap * 2)
-]
-
-{ #category : #'instance creation' }
-GtHomeSection >> newCardsContainer [
-	^ BlElement new
-		layout: BlFlowLayout new;
-		constraintsDo: [ :c |
-			c horizontal matchParent.
-			c vertical fitContent ];
-		padding: (BlInsets all: 0)
 ]
 
 { #category : #'instance creation' }

--- a/src/GToolkit-World/GtHomeToolsSection.class.st
+++ b/src/GToolkit-World/GtHomeToolsSection.class.st
@@ -8,6 +8,17 @@ Class {
 }
 
 { #category : #'private - accessing' }
+GtHomeToolsSection >> allButtons [
+	"Answer the buttons to be displayed in the GT home tab.
+	Buttons are defined by methods with the #gtToolButton pragma and sorted by priority."
+
+	^ self allButtonStencils collect: [ :stencil |
+		[ stencil create ]
+			on: Error
+			do: [ :ex | (self handleButtonCreationException: ex) create ] ]
+]
+
+{ #category : #'private - accessing' }
 GtHomeToolsSection >> allButtonStencils [
 	"Answer the stencils to be displayed in the GT home tab.
 	Buttons are defined by methods with the #gtToolButton pragma and sorted by priority."
@@ -20,17 +31,6 @@ GtHomeToolsSection >> allButtonStencils [
 				on: Error
 				do: [ :ex | self handleButtonCreationException: ex ] ])
 					sorted: #priority ascending
-]
-
-{ #category : #'private - accessing' }
-GtHomeToolsSection >> allButtons [
-	"Answer the buttons to be displayed in the GT home tab.
-	Buttons are defined by methods with the #gtToolButton pragma and sorted by priority."
-
-	^ self allButtonStencils collect: [ :stencil |
-		[ stencil create ]
-			on: Error
-			do: [ :ex | (self handleButtonCreationException: ex) create ] ]
 ]
 
 { #category : #'api - instantiation' }

--- a/src/GToolkit-World/GtWorldElement.class.st
+++ b/src/GToolkit-World/GtWorldElement.class.st
@@ -105,13 +105,14 @@ GtWorldElement >> initializeShortcuts [
 		addShortcut: (BlShortcutWithAction new
 				name: 'Select previous tab';
 				repeatable: true;
-				combination: (BlKeyCombinationBuilder new primary shift key: BlKeyboardKey leftBracket) build;
+				combination: (BlKeyCombinationBuilder new  control shift key: BlKeyboardKey tab)
+						build;
 				action: [ self tabs selectTabToTheLeft ]).
 	self
 		addShortcut: (BlShortcutWithAction new
 				name: 'Select next tab';
 				repeatable: true;
-				combination: (BlKeyCombinationBuilder new primary shift key: BlKeyboardKey rightBracket)
+				combination: (BlKeyCombinationBuilder new  control key: BlKeyboardKey tab)
 						build;
 				action: [ self tabs selectTabToTheRight ]).
 	self

--- a/src/GToolkit-World/GtWorldTabElement.class.st
+++ b/src/GToolkit-World/GtWorldTabElement.class.st
@@ -142,11 +142,6 @@ GtWorldTabElement >> initializeTabs [
 ]
 
 { #category : #'private - instance creation' }
-GtWorldTabElement >> newActionItemsInto: anActionbar [
-	"Subclasses may add action items into the World toolbar"
-]
-
-{ #category : #'private - instance creation' }
 GtWorldTabElement >> newActionbar [
 	| anActionbar |
 
@@ -156,6 +151,11 @@ GtWorldTabElement >> newActionbar [
 	self newActionItemsInto: anActionbar.
 
 	^ anActionbar
+]
+
+{ #category : #'private - instance creation' }
+GtWorldTabElement >> newActionItemsInto: anActionbar [
+	"Subclasses may add action items into the World toolbar"
 ]
 
 { #category : #'private - instance creation' }


### PR DESCRIPTION
Update move tab shortcuts to CTRL + TAB and CTRL + SHIFT + TAB (application standard) instead of  CTRL + [ and CTRL + ] (unreacheable on swiss keyboards)