### PR TITLE
[Enh]: Package Maps - Spawn RPackage if Loaded

### DIFF
--- a/src/GToolkit-Extensions/ConfigurationOf.extension.st
+++ b/src/GToolkit-Extensions/ConfigurationOf.extension.st
@@ -152,7 +152,17 @@ ConfigurationOf class >> paintPackagesMapWith: mondrian [
 	projects := self project version projects.
 	mondrian nodes 
 		stencil: [ :packageSpec |
-			BlTextElement new text: packageSpec name asRopedText ];
+			| element |
+			element := BlTextElement new.
+			element
+				when: BlClickEvent do: [ :e | 
+					| toSpawn |
+					toSpawn := RPackage organizer 
+						packageNamed: packageSpec name 
+						ifAbsent: [ packageSpec ].
+					e consumed: true.
+					element phlow spawnObject: toSpawn ];
+				text: packageSpec name asRopedText ];
 		with: packages.
 	mondrian nodes 
 		stencil: [ :projectSpec |
@@ -160,8 +170,12 @@ ConfigurationOf class >> paintPackagesMapWith: mondrian [
 			element := BlTextElement new.
 			element 
 				when: BlClickEvent do: [ :e | 
+					| toSpawn |
+					toSpawn := Smalltalk globals 
+						at: projectSpec constructClassName asSymbol
+						ifAbsent: [ projectSpec ].
 					e consumed: true. 
-					element phlow spawnObject: (Smalltalk globals at: projectSpec constructClassName asSymbol) ];
+					element phlow spawnObject: toSpawn ];
 				text: (projectSpec name asRopedText foreground: Color gray) ];
 		with: projects.
 	packages do: [ :p | 


### PR DESCRIPTION
... or package spec otherwise

Before: 
- When clicking on nodes representing *loaded* artifacts, the behavior is not consistent. For baseline nodes (e.g. `PharoEnhancements` in the screencast), the baseline class is spawned, but for package nodes (e.g. `Magritte-Money` in screencast), the package *spec* is spawned, not the package itself.
- When clicking on a node representing an *unloaded* baseline (`Seaside3` in screencast), an error occurs.

https://github.com/user-attachments/assets/95c0c790-dc58-4530-868e-ff5d8bc80d8b

After: 
- When clicking on a loaded package's node, spawn the package
- When clicking on an unloaded baseline node, spawn the spec.

https://github.com/user-attachments/assets/98f495ea-3efe-4e29-957a-b509bba83f53


