### PR TITLE
Make GtWorldTabElement closeable through middle mouse button click

### DIFF
--- a/src/GToolkit-World/GtWorldTabElement.class.st
+++ b/src/GToolkit-World/GtWorldTabElement.class.st
@@ -143,6 +143,15 @@ GtWorldTabElement >> createBaseTab: aSpace [
 ]
 
 { #category : #'api - opening' }
+GtWorldTabElement >> createTabCloseHandlerFor: aTab [
+	^ BlEventHandler
+		on: BlMouseDownEvent
+		do: [ :aBlMouseDownEvent | 
+			aBlMouseDownEvent button = BlMouseMiddleButton uniqueInstance
+				ifTrue: [ tabs viewModel removeTab: aTab viewModel ] ]
+]
+
+{ #category : #'api - opening' }
 GtWorldTabElement >> createTabDragHandler [
 	^ BlDragHandler new
 		restrictDragToHorizontal;
@@ -400,6 +409,8 @@ GtWorldTabElement >> showSpace: aSpace select: shouldBeSelected [
 		actionbarStencil: [ :aTabModel | self newToolbarForTabModel: aTabModel ].
 
 	aTab addEventHandler: self createTabDragHandler.
+
+	aTab addEventHandler: (self createTabCloseHandlerFor: aTab).
 
 	aTab
 		addAptitude: (BrLazyStyleCommonAptitude new

--- a/src/GToolkit-World/GtWorldTabElementExamples.class.st
+++ b/src/GToolkit-World/GtWorldTabElementExamples.class.st
@@ -112,6 +112,39 @@ GtWorldTabElementExamples >> showSpaceSelectScripter_04_checkSpaceGarbageCollect
 	^ aScripter
 ]
 
+{ #category : #'examples - scripter' }
+GtWorldTabElementExamples >> showSpaceSelectScripter_05_middleMouseButtonClickClosesTab [
+	<gtExample>
+	<return: #BlScripter>
+	| aScripter |
+	aScripter := self showSpaceSelectScripter_01_addSpace.
+
+	aScripter
+		mouseMoveOverStep: [ :s | 
+			s
+				label: 'Move mouse over the tab';
+				id: (GtWorldTabElement tabNameForSpaceId: aScripter model) ].
+
+	aScripter fire
+		referenceSender;
+		label: 'Simulate a middle mouse button click at the tab';
+		event: (BlMouseDownEvent middle
+				position: ((aScripter userData includesKey: #mousePosition)
+						ifTrue: [ aScripter userData at: #mousePosition ]
+						ifFalse: [ 0.0 @ 0.0 ]));
+		id: (GtWorldTabElement tabNameForSpaceId: aScripter model);
+		play.
+
+	aScripter
+		checkStep: [ :s | 
+			s
+				label: 'Check that there is no more space tab';
+				value: [ :theTabGroup | theTabGroup tabs size ] equals: 1;
+				onChildFromMessage: #tabs ].
+
+	^ aScripter
+]
+
 { #category : #'examples - show space' }
 GtWorldTabElementExamples >> showSpaceSelect_ReleaseSpaceOnSelectedTabCloseAction [
 	<gtExample>


### PR DESCRIPTION
This makes the world tab close when clicked with the middle mouse button.
Middle mouse button click closing tabs is the default in basically every graphical code editor as well as browsers.